### PR TITLE
lineage: Add flag for skipping EV_REL input in recovery

### DIFF
--- a/build/soong/android/variable.go
+++ b/build/soong/android/variable.go
@@ -14,6 +14,9 @@ type Product_variables struct {
 		Overrides []string
 		Shared_libs []string
 	}
+	Recovery_skip_ev_rel_input struct {
+		Cflags []string
+	}
 	Should_wait_for_qsee struct {
 		Cflags []string
 	}
@@ -66,6 +69,7 @@ type ProductVariables struct {
 	Should_wait_for_qsee  *bool `json:",omitempty"`
 	Specific_camera_parameter_library  *string `json:",omitempty"`
 	Supports_extended_compress_format  *bool `json:",omitempty"`
+	Recovery_skip_ev_rel_input  *bool `json:",omitempty"`
 	Supports_hw_fde  *bool `json:",omitempty"`
 	Supports_hw_fde_perf  *bool `json:",omitempty"`
 	Target_init_vendor_lib  *string `json:",omitempty"`

--- a/build/soong/soong_config.mk
+++ b/build/soong/soong_config.mk
@@ -8,6 +8,7 @@ $(call add_json_str_omitempty, Additional_gralloc_10_usage_bits, $(TARGET_ADDITI
 $(call add_json_bool, Apply_msm8974_1440p_egl_workaround, $(filter true,$(TARGET_MSM8974_1440P_EGL_WORKAROUND)))
 $(call add_json_val_default, Bootloader_message_offset, $(BOOTLOADER_MESSAGE_OFFSET), 0)
 $(call add_json_bool, Has_legacy_camera_hal1, $(filter true,$(TARGET_HAS_LEGACY_CAMERA_HAL1)))
+$(call add_json_bool, Recovery_skip_ev_rel_input, $(filter true,$(TARGET_RECOVERY_SKIP_EV_REL_INPUT)))
 $(call add_json_bool, Should_wait_for_qsee, $(filter true,$(TARGET_KEYMASTER_WAIT_FOR_QSEE)))
 $(call add_json_str, Specific_camera_parameter_library, $(TARGET_SPECIFIC_CAMERA_PARAMETER_LIBRARY))
 $(call add_json_bool, Supports_extended_compress_format, $(filter true,$(AUDIO_FEATURE_ENABLED_EXTENDED_COMPRESS_FORMAT)))


### PR DESCRIPTION
* Needed now that recovery is in bp

For fixing this: unrecognized property "product_variables.lineage.recovery_skip_ev_rel_input"

Change-Id: I625ac22e79912cbdea328eba12dc1dd16448e7a8